### PR TITLE
Fixed issue: UDP does not have connection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 SSDPClient is available through [Swift Package Manager](https://swift.org/package-manager/). To install it, add the following line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/pierrickrouxel/SSDPClient.git", from: "0.2.0")
+.package(url: "https://github.com/OliverS79/SSDPClient.git", from: "0.2.0")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 SSDPClient is available through [Swift Package Manager](https://swift.org/package-manager/). To install it, add the following line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/pierrickrouxel/SSDPClient.git", from: "0.2.0")
+.package(url: "https://github.com/cristianomatte/SSDPClient.git", from: "0.2.0")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SSDPClient ![](https://img.shields.io/badge/swift-4.0-orange.svg) ![](https://img.shields.io/badge/plataforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20linux-lightgrey.svg) ![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg) [![GitHub release](https://img.shields.io/badge/version-v0.2.0-brightgreen.svg)](https://github.com/pierrickrouxel/SSDPClient/releases) ![Github stable](https://img.shields.io/badge/stable-true-brightgreen.svg)
+# SSDPClient ![](https://img.shields.io/badge/swift-4.0-orange.svg) ![](https://img.shields.io/badge/plataforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20linux-lightgrey.svg) ![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg) [![GitHub release](https://img.shields.io/badge/version-v0.2.1-brightgreen.svg)](https://github.com/pierrickrouxel/SSDPClient/releases) ![Github stable](https://img.shields.io/badge/stable-true-brightgreen.svg)
 
 [SSDP](https://en.wikipedia.org/wiki/Simple_Service_Discovery_Protocol) client for Swift using the Swift Package Manager. Works on iOS, macOS, tvOS, watchOS and Linux.
 
@@ -8,7 +8,7 @@
 SSDPClient is available through [Swift Package Manager](https://swift.org/package-manager/). To install it, add the following line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/OliverS79/SSDPClient.git", from: "0.2.0")
+.package(url: "https://github.com/OliverS79/SSDPClient.git", from: "0.2.1")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 SSDPClient is available through [Swift Package Manager](https://swift.org/package-manager/). To install it, add the following line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/OliverS79/SSDPClient.git", from: "0.2.1")
+.package(url: "https://github.com/pierrickrouxel/SSDPClient.git", from: "0.2.1")
 ```
 
 ## Usage

--- a/Sources/SSDPClient/SSDPDiscovery.swift
+++ b/Sources/SSDPClient/SSDPDiscovery.swift
@@ -42,7 +42,7 @@ public class SSDPDiscovery {
     /// The client is discovering
     public var isDiscovering: Bool {
         get {
-            return self.socket != nil && self.socket!.isConnected
+            return self.socket != nil
         }
     }
 
@@ -83,9 +83,9 @@ public class SSDPDiscovery {
         let queue = DispatchQueue.global()
 
         queue.async() {
-            repeat {
+            while self.isDiscovering {
                 self.readResponses()
-            } while self.isDiscovering
+            }
         }
 
         queue.asyncAfter(deadline: .now() + duration) { [unowned self] in


### PR DESCRIPTION
I think for UDP connections `isConnected` is always `false`, thus `isDiscovering` is always `false`. 

This fix should allow multiple devices to be reported.