### PR TITLE
Support case insensitive header names

### DIFF
--- a/Sources/SSDPClient/SSDPService.swift
+++ b/Sources/SSDPClient/SSDPService.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let HeaderRegex = try! NSRegularExpression(pattern: "^([^:]+): (.*)$", options: [.anchorsMatchLines])
+
 public class SSDPService {
     /// The host of service
     public internal(set) var host: String
@@ -23,13 +25,35 @@ public class SSDPService {
     */
     init(host: String, response: String) {
         self.host = host
-        self.location = self.parse(header: "LOCATION", in: response)
-        self.server = self.parse(header: "SERVER", in: response)
-        self.searchTarget = self.parse(header: "ST", in: response)
-        self.uniqueServiceName = self.parse(header: "USN", in: response)
+        let headers = self.parse(response)
+        self.location = headers["LOCATION"]
+        self.server = headers["SERVER"]
+        self.searchTarget = headers["ST"]
+        self.uniqueServiceName = headers["USN"]
     }
 
     // MARK: Private functions
+    
+    /**
+        Parse the discovery response.
+     
+        - Parameters:
+            - response: The discovery response.
+     */
+    private func parse(_ response: String) -> [String: String] {
+        var result = [String: String]()
+        
+        let matches = HeaderRegex.matches(in: response, range: NSRange(location: 0, length: response.count))
+        for match in matches {
+            let keyCaptureGroupIndex = match.range(at: 1)
+            let key = (response as NSString).substring(with: keyCaptureGroupIndex)
+            let valueCaptureGroupIndex = match.range(at: 2)
+            let value = (response as NSString).substring(with: valueCaptureGroupIndex)
+            result[key.uppercased()] = value
+        }
+        
+        return result
+    }
 
     /**
         Parse the discovery response.
@@ -38,12 +62,4 @@ public class SSDPService {
             - header: The header to parse.
             - response: The discovery response.
     */
-    private func parse(header: String, in response: String) -> String? {
-        if let range = response.range(of: "\(header): .*", options: .regularExpression) {
-            var value = String(response[range])
-            value = value.replacingOccurrences(of: "\(header): ", with: "")
-            return value
-        }
-        return nil
-    }
 }

--- a/Sources/SSDPClient/SSDPService.swift
+++ b/Sources/SSDPClient/SSDPService.swift
@@ -54,12 +54,4 @@ public class SSDPService {
         
         return result
     }
-
-    /**
-        Parse the discovery response.
-
-        - Parameters:
-            - header: The header to parse.
-            - response: The discovery response.
-    */
 }

--- a/Tests/SSDPClientTests/SSDPDiscoveryTests.swift
+++ b/Tests/SSDPClientTests/SSDPDiscoveryTests.swift
@@ -4,6 +4,11 @@ import XCTest
 let duration: TimeInterval = 5
 
 class SSDPDiscoveryTests: XCTestCase {
+    static var allTests = [
+        ("testDiscoverService", testDiscoverService),
+        ("testStop", testStop),
+    ]
+    
     let client = SSDPDiscovery()
 
     var discoverServiceExpectation: XCTestExpectation?
@@ -38,11 +43,6 @@ class SSDPDiscoveryTests: XCTestCase {
         self.client.stop()
         wait(for: [self.errorExpectation!, self.stopExpectation!], timeout: duration)
     }
-
-    static var allTests = [
-        ("testDiscoverService", testDiscoverService),
-        ("testStop", testStop),
-    ]
 }
 
 extension SSDPDiscoveryTests: SSDPDiscoveryDelegate {

--- a/Tests/SSDPClientTests/SSDPServiceTests.swift
+++ b/Tests/SSDPClientTests/SSDPServiceTests.swift
@@ -11,18 +11,46 @@ let response = "HTTP/1.1 200 OK\r\n" +
     "LOCATION: http://192.168.1.1:10000/root.xml\r\n" +
     "OPT: \"http://schemas.upnp.org/upnp/1/0/\"; ns=01\r\n\r\n"
 
+let responseCaseInsensitive = "HTTP/1.1 200 OK\r\n" +
+    "CACHE-CONTROL: max-age=120\r\n" +
+    "St: upnp:rootdevice\r\n" +
+    "Usn: uuid:111111111-2222-3333-4444-000000000000::upnp:rootdevice\r\n" +
+    "EXT:\r\n" +
+    "Server: system/system UPnP/1.1 MiniUPnPd/1.8\r\n" +
+    "Location: http://192.168.1.1:10000/root.xml\r\n" +
+    "OPT: \"http://schemas.upnp.org/upnp/1/0/\"; ns=01\r\n\r\n"
+
 class SSDPServiceTests: XCTestCase {
-    let service = SSDPService(host: "192.168.1.1", response: response)
-
-    func testParse() {
-        XCTAssertEqual("192.168.1.1", self.service.host)
-        XCTAssertEqual("upnp:rootdevice", self.service.searchTarget!)
-        XCTAssertEqual("uuid:111111111-2222-3333-4444-000000000000::upnp:rootdevice", self.service.uniqueServiceName!)
-        XCTAssertEqual("system/system UPnP/1.1 MiniUPnPd/1.8", self.service.server!)
-        XCTAssertEqual("http://192.168.1.1:10000/root.xml", self.service.location!)
-    }
-
     static var allTests = [
         ("testParse", testParse),
+        ("testParseCaseInsensitive", testParseCaseInsensitive),
     ]
+    
+    func testParse() {
+        let service = SSDPService(host: "192.168.1.1", response: response)
+        
+        XCTAssertEqual("192.168.1.1", service.host)
+        XCTAssertNotNil(service.searchTarget)
+        XCTAssertEqual("upnp:rootdevice", service.searchTarget)
+        XCTAssertNotNil(service.uniqueServiceName)
+        XCTAssertEqual("uuid:111111111-2222-3333-4444-000000000000::upnp:rootdevice", service.uniqueServiceName)
+        XCTAssertNotNil(service.server)
+        XCTAssertEqual("system/system UPnP/1.1 MiniUPnPd/1.8", service.server)
+        XCTAssertNotNil(service.location)
+        XCTAssertEqual("http://192.168.1.1:10000/root.xml", service.location)
+    }
+    
+    func testParseCaseInsensitive() {
+        let service = SSDPService(host: "192.168.1.1", response: responseCaseInsensitive)
+        
+        XCTAssertEqual("192.168.1.1", service.host)
+        XCTAssertNotNil(service.searchTarget)
+        XCTAssertEqual("upnp:rootdevice", service.searchTarget)
+        XCTAssertNotNil(service.uniqueServiceName)
+        XCTAssertEqual("uuid:111111111-2222-3333-4444-000000000000::upnp:rootdevice", service.uniqueServiceName)
+        XCTAssertNotNil(service.server)
+        XCTAssertEqual("system/system UPnP/1.1 MiniUPnPd/1.8", service.server)
+        XCTAssertNotNil(service.location)
+        XCTAssertEqual("http://192.168.1.1:10000/root.xml", service.location)
+    }
 }


### PR DESCRIPTION
The current implementation only supports fully uppercase header names, but some implementations will send them in different casing.