### PR TITLE
Exposed all response headers, fixed parsing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The `SSDPDiscoveryDelegate` protocol defines delegate methods that you should im
 * `server: String?` - The value of `SERVER` header
 * `searchTarget: String?` - The value of `ST` header
 * `uniqueServiceName: String?` - The value of `USN` header
+* `responseHeaders: [String: String]?` - Key-Value pairs of all original response headers
 
 ## Test
 Run test:

--- a/Sources/SSDPClient/SSDPService.swift
+++ b/Sources/SSDPClient/SSDPService.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-private let HeaderRegex = try! NSRegularExpression(pattern: "^([^:]+): (.*)$", options: [.anchorsMatchLines])
+private let HeaderRegex = try! NSRegularExpression(pattern: "^([^\r\n:]+): (.*)$", options: [.anchorsMatchLines])
 
 public class SSDPService {
     /// The host of service
     public internal(set) var host: String
+    /// The headers of the original response
+    public internal(set) var responseHeaders: [String: String]?
     /// The value of `LOCATION` header
     public internal(set) var location: String?
     /// The value of `SERVER` header
@@ -25,7 +27,10 @@ public class SSDPService {
     */
     init(host: String, response: String) {
         self.host = host
+        
         let headers = self.parse(response)
+        self.responseHeaders = headers
+        
         self.location = headers["LOCATION"]
         self.server = headers["SERVER"]
         self.searchTarget = headers["ST"]

--- a/Tests/SSDPClientTests/SSDPServiceTests.swift
+++ b/Tests/SSDPClientTests/SSDPServiceTests.swift
@@ -38,6 +38,8 @@ class SSDPServiceTests: XCTestCase {
         XCTAssertEqual("system/system UPnP/1.1 MiniUPnPd/1.8", service.server)
         XCTAssertNotNil(service.location)
         XCTAssertEqual("http://192.168.1.1:10000/root.xml", service.location)
+        XCTAssertEqual("max-age=120", service.responseHeaders?["CACHE-CONTROL"])
+        XCTAssertEqual("\"http://schemas.upnp.org/upnp/1/0/\"; ", service.responseHeaders?["OPT"])
     }
     
     func testParseCaseInsensitive() {
@@ -52,5 +54,7 @@ class SSDPServiceTests: XCTestCase {
         XCTAssertEqual("system/system UPnP/1.1 MiniUPnPd/1.8", service.server)
         XCTAssertNotNil(service.location)
         XCTAssertEqual("http://192.168.1.1:10000/root.xml", service.location)
+        XCTAssertEqual("max-age=120", service.responseHeaders?["CACHE-CONTROL"])
+        XCTAssertEqual("\"http://schemas.upnp.org/upnp/1/0/\"; ", service.responseHeaders?["OPT"])
     }
 }


### PR DESCRIPTION
Added the ability for users to access headers that aren't explicitly set on the Service object.

Fixed an issue where the HTTP response status  was being combined with the first header:

`HTTP/1.1 200 OK\r\nCACHE-CONTROL`