### PR TITLE
Add ability to discover devices on all local interfaces (subnets)

### DIFF
--- a/Sources/SSDPClient/SSDPDiscovery.swift
+++ b/Sources/SSDPClient/SSDPDiscovery.swift
@@ -34,7 +34,7 @@ public extension SSDPDiscoveryDelegate {
 public class SSDPDiscovery {
 
     /// The UDP socket
-    private var socket: Socket?
+    private var sockets: [Socket] = []
 
     /// Delegate for service discovery
     public var delegate: SSDPDiscoveryDelegate?
@@ -42,10 +42,10 @@ public class SSDPDiscovery {
     /// The client is discovering
     public var isDiscovering: Bool {
         get {
-            return self.socket != nil
+            return self.sockets.count > 0
         }
     }
-
+    
     // MARK: Initialisation
 
     public init() {
@@ -60,21 +60,23 @@ public class SSDPDiscovery {
 
     /// Read responses.
     private func readResponses() {
-        do {
-            var data = Data()
-            let (bytesRead, address) = try self.socket!.readDatagram(into: &data)
+        for socket in self.sockets {
+            do {
+                var data = Data()
+                let (bytesRead, address) = try socket.readDatagram(into: &data)
 
-            if bytesRead > 0 {
-                let response = String(data: data, encoding: .utf8)
-                let (remoteHost, _) = Socket.hostnameAndPort(from: address!)!
-                Log.debug("Received: \(response!) from \(remoteHost)")
-                self.delegate?.ssdpDiscovery(self, didDiscoverService: SSDPService(host: remoteHost, response: response!))
+                if bytesRead > 0 {
+                    let response = String(data: data, encoding: .utf8)
+                    let (remoteHost, _) = Socket.hostnameAndPort(from: address!)!
+                    Log.debug("Received: \(response!) from \(remoteHost)")
+                    self.delegate?.ssdpDiscovery(self, didDiscoverService: SSDPService(host: remoteHost, response: response!))
+                }
+
+            } catch let error {
+                Log.error("Socket error: \(error)")
+                self.forceStop()
+                self.delegate?.ssdpDiscovery(self, didFinishWithError: error)
             }
-
-        } catch let error {
-            Log.error("Socket error: \(error)")
-            self.forceStop()
-            self.delegate?.ssdpDiscovery(self, didFinishWithError: error)
         }
     }
 
@@ -95,10 +97,9 @@ public class SSDPDiscovery {
 
     /// Force stop discovery closing the socket.
     private func forceStop() {
-        if self.isDiscovering {
-            self.socket!.close()
+        while self.isDiscovering {
+            self.sockets.removeLast().close()
         }
-        self.socket = nil
     }
 
     // MARK: Public functions
@@ -109,7 +110,7 @@ public class SSDPDiscovery {
             - duration: The amount of time to wait.
             - searchTarget: The type of the searched service.
     */
-    open func discoverService(forDuration duration: TimeInterval = 10, searchTarget: String = "ssdp:all", port: Int32 = 1900) {
+    open func discoverService(forDuration duration: TimeInterval = 10, searchTarget: String = "ssdp:all", port: Int32 = 1900, onInterfaces:[String?] = [nil]) {
         Log.info("Start SSDP discovery for \(Int(duration)) duration...")
         self.delegate?.ssdpDiscoveryDidStart(self)
 
@@ -118,26 +119,37 @@ public class SSDPDiscovery {
             "HOST: 239.255.255.250:\(port)\r\n" +
             "ST: \(searchTarget)\r\n" +
             "MX: \(Int(duration))\r\n\r\n"
+        
+        for interface in onInterfaces {
+            var socket: Socket? = nil
+            do {
+                socket = try Socket.create(type: .datagram, proto: .udp)
+                if let socket = socket {
+                    try socket.listen(on: 0, node: interface)   // node:nil means the default interface, for all others it should be the interface's IP address
+                    // Use Multicast (Caution: Gets blocked by iOS 16 unless the app has the multicast entitlement!)
+                    try socket.write(from: message, to: Socket.createAddress(for: "239.255.255.250", on: port)!)
+                    self.sockets.append(socket)
+                }
+            } catch let error {
+                // We ignore errors here because we get "-9980(0x-26FC), No route to host" if we're not allowed to multicast, and that's difficult to foresee.
+                // Also, with multiple interfaces, some may fail, and we need to ignore that, too, or it gets too difficult to handle for the caller
+                // to sort out which work and which don't.
+                socket?.close();
+                Log.info("Socket error: \(error) on interface \(interface ?? "default")")
+            }
+        }
 
-        do {
-            self.socket = try Socket.create(type: .datagram, proto: .udp)
-            try self.socket!.listen(on: 0)
-
+        if !self.isDiscovering {    // Might we run into a race condition here?
+            //Log.info("Failed SSDP discovery")
+            self.delegate?.ssdpDiscoveryDidFinish(self)
+        } else {
             self.readResponses(forDuration: duration)
-
-            Log.debug("Send: \(message)")
-            try self.socket?.write(from: message, to: Socket.createAddress(for: "239.255.255.250", on: port)!)
-
-        } catch let error {
-            Log.error("Socket error: \(error)")
-            self.forceStop()
-            self.delegate?.ssdpDiscovery(self, didFinishWithError: error)
         }
     }
-
+    
     /// Stop the discovery before the timeout.
     open func stop() {
-        if self.socket != nil {
+        if self.isDiscovering {
             Log.info("Stop SSDP discovery")
             self.forceStop()
             self.delegate?.ssdpDiscoveryDidFinish(self)

--- a/Sources/SSDPClient/SSDPService.swift
+++ b/Sources/SSDPClient/SSDPService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private let HeaderRegex = try! NSRegularExpression(pattern: "^([^\r\n:]+): (.*)$", options: [.anchorsMatchLines])
 
-public class SSDPService {
+public class SSDPService: CustomStringConvertible {
     /// The host of service
     public internal(set) var host: String
     /// The headers of the original response
@@ -35,6 +35,10 @@ public class SSDPService {
         self.server = headers["SERVER"]
         self.searchTarget = headers["ST"]
         self.uniqueServiceName = headers["USN"]
+    }
+
+    public var description: String {
+        return "loc: \(self.location!), server: \(self.server!), st: \(self.searchTarget!), usn: \(self.uniqueServiceName!)"
     }
 
     // MARK: Private functions


### PR DESCRIPTION
Should resolve issue #17

I had to disable the code that would abort the discovery if there's an error with the socket, as it's now possible that some of the specified interfaces fail (e.g. due to "not reachable"), yet we want the rest to continue to work.

If all of them fail, then I report that the search is finished, though I'm not sure if that may run into a race condition. Or maybe one should in that special case still report an error.

I leave that up to you. The way it's now it works nicely for me.

Hope this helps, and thank you for providing this code in the first place!
